### PR TITLE
Add scaleToZeroOnNoEvents parameter to control minimum replica behavi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Required parameters
 * endColumn: column name of the end time
 * desiredReplicasColumn: column name of the desired replicas
 * timezone: timezone name (e.g., "Asia/Tokyo")
+* scaleToZeroOnNoEvents: (Optional) Controls whether to scale to zero when no events are found. Set to "false" to always keep minimum replicas (default: "true")
 
 ```yaml
 triggers:
@@ -41,21 +42,22 @@ triggers:
     passwordFromEnv: <password>
     table: <table>
     timezone: <timezone>
-
     startColumn: <start_column>
     endColumn: <end_column>
     desiredReplicasColumn: <desired_replicas_column>
+    scaleToZeroOnNoEvents: "false"  # Optional (default: true): set to "false" to prevent scaling to zero
 ```
 
 ### DynamoDB
 
-- type: `dynamodb`
-- region: AWS Region
-- table: Table name of dynamodb.
-- startAttribute: Field name of the start time.
-- endAttribute: Field name of the end time.
-- desiredReplicasAttribute: Field name of desired replicas.
-- timezone: Timezone(ex. Asia/Tokyo)
+* type: `dynamodb`
+* region: AWS Region
+* table: Table name of dynamodb.
+* startAttribute: Field name of the start time.
+* endAttribute: Field name of the end time.
+* desiredReplicasAttribute: Field name of desired replicas.
+* timezone: Timezone(ex. Asia/Tokyo)
+* scaleToZeroOnNoEvents: (Optional) Controls whether to scale to zero when no events are found. Set to "false" to always keep minimum replicas (default: "true")
 
 ```yaml
 triggers:
@@ -69,6 +71,7 @@ triggers:
     startAttribute: <start_attribute>
     endAttribute: <end_attribute>
     desiredReplicasAttribute: <desired_replicas_attribute>
+    scaleToZeroOnNoEvents: "false"  # Optional (default: true): set to "false" to prevent scaling to zero
 ```
 
 > Note: startAttribute, endAttribute cannot be set to the reserved keyword of DynamoDB such as `start`, `end`, etc.


### PR DESCRIPTION
This pull request introduces a new optional parameter, `scaleToZeroOnNoEvents`, to control scaling behavior when no events are detected. It updates the documentation and implements the logic in the codebase to support this feature.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30): Added `scaleToZeroOnNoEvents` as an optional parameter in the `Required parameters` and `triggers` sections for both general and DynamoDB-specific configurations. This parameter allows users to prevent scaling to zero by setting it to `"false"` (default: `"true")`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R60) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74)

### Code Implementation:
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R22-R30): Updated the `IsActive` method in the `ExternalScaler` struct to check for the `scaleToZeroOnNoEvents` parameter. If set to `"false"`, the method ensures the scaler always returns `active=true`, preventing scaling to zero.…or in KEDA ScaledObject