### PR TITLE
add support for pushing Docker images to GitHub Container Registry

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,11 +54,20 @@ jobs:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
         
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.REGISTRY }}/${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.IMAGE_NAME }}
+        images: |
+          ${{ env.REGISTRY }}/${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
         tags: |
           type=raw,value=latest
           type=sha,format=short
@@ -75,3 +84,13 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Update DockerHub description
+      uses: peter-evans/dockerhub-description@v4
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+        repository: fsat0/keda-calendar-scaler
+        readme-filepath: ./README.md
+        short-description: "KEDA external scaler for calendar-based scaling"
+        homepage: "https://github.com/fsat0/keda-calendar-scaler"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: CD - Build and Push to Docker Hub
+name: CD - Build and Push to DockerHub
 
 on:
   push:
@@ -48,7 +48,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Log in to Docker Hub
+    - name: Log in to DockerHub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -90,7 +90,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
-        repository: fsat0/keda-calendar-scaler
+        repository: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.IMAGE_NAME }}
         readme-filepath: ./README.md
         short-description: "KEDA external scaler for calendar-based scaling"
         homepage: "https://github.com/fsat0/keda-calendar-scaler"


### PR DESCRIPTION
This pull request updates the `.github/workflows/cd.yml` file to enhance the CI/CD pipeline by adding support for publishing to GitHub Container Registry (GHCR) and updating the DockerHub repository description. 

### Enhancements to CI/CD pipeline:

* **Added GHCR login step**: Introduced a new step to log in to GitHub Container Registry (GHCR) using the `docker/login-action@v3` action. This ensures that images can be pushed to GHCR.
* **Updated Docker image metadata**: Modified the `docker/metadata-action@v5` step to include GHCR as an additional image target alongside DockerHub. This allows the same image to be published to both registries.

### DockerHub repository improvements:

* **Automated DockerHub description update**: Added a step to update the DockerHub repository description using the `peter-evans/dockerhub-description@v4` action. This ensures the repository metadata, including the description, README, and homepage link, remains up-to-date.